### PR TITLE
Setting up some minor protection placeholders for backend API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__/
+.github/
+.venv/
+.env
+.envExample
+.gitignore
+LICENSE
+README.md

--- a/.envExample
+++ b/.envExample
@@ -1,0 +1,1 @@
+FRONTEND_URL = ""

--- a/.envExample
+++ b/.envExample
@@ -1,1 +1,3 @@
+# example showing which variables are set in .env or a kubernetes ConfigMap
+# needs to be set for apps to run correctly
 FRONTEND_URL = ""

--- a/.envExample
+++ b/.envExample
@@ -1,3 +1,6 @@
 # example showing which variables are set in .env or a kubernetes ConfigMap
 # needs to be set for apps to run correctly
 FRONTEND_URL = ""
+# The request header from the frontend will contain an 'X-api-key' which 
+# must match with this key to allow API operations
+API_KEY = ""

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import os
+from dotenv import load_dotenv
 
 from flask import Flask
 from flask_smorest import Api
@@ -10,8 +11,10 @@ from db import db
 from resources.articles import blp as ArticleBlueprint
 
 def create_app(db_url=None):
+    load_dotenv(override=True)
+
     app = Flask(__name__)
-    CORS(app, origins=["*"])
+    CORS(app, origins=[os.getenv("FRONTEND_URL")])
 
     app.config["PROPAGATE_EXCEPTIONS"] = True
     app.config["API_TITLE"] = "Precision Medicine Portal REST API"

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import os
 from flask import Flask
 from flask_smorest import Api
 from flask_migrate import Migrate
+from flask_cors import CORS
 
 from db import db
 
@@ -10,6 +11,7 @@ from resources.articles import blp as ArticleBlueprint
 
 def create_app(db_url=None):
     app = Flask(__name__)
+    CORS(app, origins=["*"])
 
     app.config["PROPAGATE_EXCEPTIONS"] = True
     app.config["API_TITLE"] = "Precision Medicine Portal REST API"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv
 sqlalchemy
 flask-sqlalchemy
 flask-migrate
+flask_cors

--- a/resources/articles.py
+++ b/resources/articles.py
@@ -7,24 +7,28 @@ from models import ArticleModel
 from schemas import ArticleGetSchema, PlainArticleSchema, ArticleUpdateSchema
 
 from utils import generate_url_from_title
+from security import api_key_required
 
 
 blp = Blueprint("Articles", __name__, description="Operations on articles")
 
 @blp.route("/article/<string:article_id>")
 class Article(MethodView):
+    @api_key_required
     @blp.response(200, ArticleGetSchema)
     def get(self, article_id):
         # from flask sql-alchemy, automatically aborts if not found
         article = ArticleModel.query.get_or_404(article_id)
         return article
 
+    @api_key_required
     def delete(self, article_id):
         article = ArticleModel.query.get_or_404(article_id)
         db.session.delete(article)
         db.session.commit()
         return {"message": "Article deleted."}
 
+    @api_key_required
     @blp.arguments(ArticleUpdateSchema)
     @blp.response(200, ArticleGetSchema)
     def put(self, article_data, article_id):
@@ -47,10 +51,12 @@ class Article(MethodView):
 
 @blp.route("/article")
 class ArticleList(MethodView):
+    @api_key_required
     @blp.response(200, ArticleGetSchema(many=True))
     def get(self):
         return ArticleModel.query.all()
     
+    @api_key_required
     @blp.arguments(PlainArticleSchema)
     @blp.response(201, ArticleGetSchema)
     def post(self, article_data):

--- a/security.py
+++ b/security.py
@@ -1,0 +1,32 @@
+import os
+
+import functools
+from flask import request
+from flask_smorest import abort
+
+def is_valid(api_key):
+    return os.getenv("API_KEY") == api_key
+
+def api_key_required(func):
+    @functools.wraps(func)
+    def decorator(*args, **kwargs):
+        api_key = request.headers.get("x-api-key")
+        print("headers: ")
+        for item in list(request.headers):
+            print(item)
+        print("api_key: ")
+        print(api_key)
+        if not api_key:
+            abort(
+                400, 
+                message="Please provide an API key."
+            )
+        # Check if API key is correct and valid
+        if is_valid(api_key):
+            return func(*args, **kwargs)
+        else:
+            abort(
+                403, 
+                message="The provided API key is not valid."
+            )
+    return decorator

--- a/security.py
+++ b/security.py
@@ -11,11 +11,6 @@ def api_key_required(func):
     @functools.wraps(func)
     def decorator(*args, **kwargs):
         api_key = request.headers.get("x-api-key")
-        print("headers: ")
-        for item in list(request.headers):
-            print(item)
-        print("api_key: ")
-        print(api_key)
         if not api_key:
             abort(
                 400, 


### PR DESCRIPTION
Added flask_CORS to only allow requests from the desired frontend in the current environment (set using environmental variables).

Added a security decorator that can be added to endpoints. Fetches request headers and checks if the header 'X-api-key' exists as well as comparing it to some set header key. If the 'X-api-key' does not match, the request is rejected. 

If the API was exposed and in production, this header api key would have to be secret, but for testing purposes it's just set in a configmap and consumed as an environmental variable.