### PR TITLE
other/469-adding-codeowners-files

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ScilifelabDataCentre/TeamPinga


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/CODEOWNERS` file. The change assigns all files to the `@ScilifelabDataCentre/TeamPinga` team for ownership.